### PR TITLE
Better way to handle gzip inflating

### DIFF
--- a/lib/wwwdude/index.js
+++ b/lib/wwwdude/index.js
@@ -186,7 +186,7 @@ var createClient = exports.createClient = function createClient(clientOptions) {
 
       response.on('end', function () {
           if (useGzip) {
-            Util.decodeGzip(body, encoding, function (err, data) {
+            Util.decodeGzip(body, function (err, data) {
                 response.rawData = data;
                 _handleResponse(response);
               });

--- a/lib/wwwdude/util.js
+++ b/lib/wwwdude/util.js
@@ -11,7 +11,7 @@
 /* Module dependencies */
 
 var Url = require('url');
-var Child_process = require('child_process');
+var Compress = require('compress');
 
 /**
  * lookup table for all HTTP status codes
@@ -129,7 +129,7 @@ exports.parseUrl = function parseUrl(url) {
 };
 
 /**
- * Decode gzip content with an external gunzip command
+ * Decode gzip content
  * call request._handleResponse() when ready
  *
  * @param {Object} data
@@ -137,24 +137,15 @@ exports.parseUrl = function parseUrl(url) {
  * @return {undefined}
  * @api public
  */
-exports.decodeGzip = function decodeGzip(data, encoding, callback) {
+exports.decodeGzip = function decodeGzip(data, callback) {
   var body = '';
-  var gunzip = Child_process.spawn('gunzip', ['-9']);
-
-  gunzip.stdin.write(data, 'binary');
-  gunzip.stdin.end();
-
-  gunzip.stdout.setEncoding(encoding);
-
-  gunzip.stdout.on('data', function (data) {
-      body += data;
-    });
-
-  gunzip.on('exit', function (code) {
-      if (code === 0) {
-        callback(null, body);
-      } else {
-        callback(new Error('Process gzip returned with error code: ' + code));
-        }
-      });
-  };
+  var gunzip = new Compress.Gunzip;
+  gunzip.init();
+  
+  try{
+    body += gunzip.inflate(data.toString('binary'), 'binary') + gunzip.end();
+    callback(null, body);
+  } catch(e){
+    callback(e);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
       "url" : "http://github.com/pfleidi/node-wwwdude/raw/master/LICENSE"
     }],
   "dependencies" : {
-    "xml2js-expat" : "= 0.2.0"
+    "xml2js-expat" : "= 0.2.0",
+    "compress": "=0.1.9"
   },
   "engines" : { "node": ">= 0.2.0" },
   "main" : "index"


### PR DESCRIPTION
replacing the way gzip content encoding is handled - using the compress library to inflate gzip encoded data instead of spawning a child process
